### PR TITLE
Use go 1.9.2 on dev

### DIFF
--- a/isucon6-final/webapp/go/src/app/Dockerfile-dev
+++ b/isucon6-final/webapp/go/src/app/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM golang:1.7.3-alpine
+FROM golang:1.9.2-alpine
 
 RUN apk update \
   && apk --update add git


### PR DESCRIPTION
## WHY
goのバージョンを本番とあわせる
