### PR TITLE
Move room_watcher to redis

### DIFF
--- a/isucon6-final/webapp/go/src/app/room_watcher.go
+++ b/isucon6-final/webapp/go/src/app/room_watcher.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/garyburd/redigo/redis"
+)
+
+func roomWatcherKey(roomID int64, token string) string {
+	return fmt.Sprintf("room_watcher:%d:%s", roomID, token)
+}
+
+func getWatcherCount(roomID int64) (int, error) {
+	conn := pool.Get()
+	defer conn.Close()
+
+	keys, err := redis.Strings(conn.Do("KEYS", roomWatcherKey(roomID, "*")))
+	return len(keys), err
+}
+
+func updateRoomWatcher(roomID int64, token string) error {
+	conn := pool.Get()
+	defer conn.Close()
+
+	_, err := conn.Do("SETEX", roomWatcherKey(roomID, token), 3, token)
+	return err
+}


### PR DESCRIPTION
## WHY
room_watcher周りが地獄

```
Count: 26730  Time=0.01s (278s)  Lock=0.00s (2s)  Rows=0.0 (0), isucon[isucon]@ip-172-31-17-245.ap-northeast-1.compute.internal
  INSERT INTO `room_watchers` (`room_id`, `token_id`) VALUES (N, N) ON DUPLICATE KEY UPDATE `updated_at` = CURRENT_TIMESTAMP(N)

Count: 31446  Time=0.00s (30s)  Lock=0.00s (2s)  Rows=1.0 (31446), isucon[isucon]@ip-172-31-17-245.ap-northeast-1.compute.internal
  SELECT COUNT(*) AS `watcher_count` FROM `room_watchers` WHERE `room_id` = N AND `updated_at` > CURRENT_TIMESTAMP(N) - INTERVAL N SECOND
```

## WHAT
redisに移す